### PR TITLE
feat(docs): add Tack IPFS storage page with Tiff's feedback

### DIFF
--- a/docs/pages/guides/using-taiko-with-agents.mdx
+++ b/docs/pages/guides/using-taiko-with-agents.mdx
@@ -82,7 +82,11 @@ Every page is available as raw Markdown by appending `.md` to the URL:
 
 Taiko supports ERC-8004 on both Taiko Alethia and Taiko Hoodi, contract addresses for IdentityRegistry and ReputationRegistry can be found [here](/network/contract-addresses#key-tokens--utilities)
 
-Other agent-friendly tooling includes [tack](https://tack.taiko.xyz/), an agent-native IPFS pinning/retrieval service that implements x402 payments.
+### Tack: IPFS storage for agents
+
+[Tack](https://tack.taiko.xyz/) is an agent-native IPFS pinning and retrieval service. One endpoint, no API keys, no accounts — your agent can store and retrieve files autonomously using x402 micropayments.
+
+**[Get started with Tack →](/quickstart/tack)**
 
 ## Best practices
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -11,6 +11,11 @@ Taiko is an Ethereum-equivalent (type-1) based rollup. "Based" means Ethereum L1
 These docs cover everything from deploying your first contract to running a node and understanding the protocol.
 
 <div className="landing-cards">
+  <a href="/quickstart/tack" className="landing-card">
+    <div className="landing-card-icon">📦</div>
+    <div className="landing-card-title">Tack: IPFS for Agents</div>
+    <p className="landing-card-desc">One endpoint. Give it to your agent. No API keys, no accounts.</p>
+  </a>
   <a href="/quickstart/agent" className="landing-card">
     <div className="landing-card-icon">🤖</div>
     <div className="landing-card-title">Agent Quickstart</div>

--- a/docs/pages/quickstart/tack.mdx
+++ b/docs/pages/quickstart/tack.mdx
@@ -1,0 +1,81 @@
+---
+description: IPFS storage for AI agents. No API keys. No accounts.
+---
+
+# One endpoint. Give it to your agent. [IPFS storage for AI agents. No API keys. No accounts.]
+
+## Fully autonomous operation
+
+Your agent can store and retrieve files on IPFS without any human setup. No accounts to create, no API keys to manage, no approval flows. The agent handles everything autonomously.
+
+:::code-group
+
+```bash [Store a file]
+curl -X POST https://tack.taiko.xyz/store \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Hello from my agent"}'
+```
+
+```bash [Retrieve a file]
+curl https://tack.taiko.xyz/retrieve/<cid>
+```
+
+:::
+
+## How it works
+
+1. **Your agent calls the endpoint** — One POST request to store content, one GET to retrieve it
+2. **Tack handles storage** — Content is pinned to IPFS automatically
+3. **Payment happens inline** — x402 protocol handles USDC micropayments per request, no prepaid credits or billing accounts
+
+## Why agents love this
+
+| Feature | Benefit |
+|---------|---------|
+| **No API keys** | Agent doesn't need credentials provisioned by a human |
+| **No accounts** | No signup, no dashboard, no human in the loop |
+| **Pay-per-request** | x402 micropayments in USDC, only pay for what you use |
+| **Standard HTTP** | Works with any HTTP client, no SDKs required |
+
+## x402 payments
+
+Tack uses the [x402 protocol](https://www.x402.org/) for payments. When your agent makes a request:
+
+1. Tack returns a `402 Payment Required` response with payment details
+2. Your agent's x402-compatible client handles the USDC micropayment automatically
+3. The request completes and returns the result
+
+No wallets to configure, no transactions to sign manually. The agent handles the payment flow autonomously.
+
+## Get started
+
+Point your agent at the endpoint:
+
+```
+https://tack.taiko.xyz
+```
+
+That's it. Your agent can now store and retrieve files on IPFS.
+
+## Example: Store agent memory
+
+```python
+import requests
+
+# Store conversation context
+response = requests.post(
+    "https://tack.taiko.xyz/store",
+    json={"content": "User prefers concise responses"}
+)
+cid = response.json()["cid"]
+
+# Retrieve it later
+memory = requests.get(f"https://tack.taiko.xyz/retrieve/{cid}")
+```
+
+## Learn more
+
+- [Taiko homepage](https://taiko.xyz) — Learn about Taiko's based rollup
+- [Taiko documentation](https://docs.taiko.xyz) — Full developer documentation
+- [Agent Quickstart](/quickstart/agent) — Deploy contracts and bridge tokens with your agent
+- [Using Taiko with Agents](/guides/using-taiko-with-agents) — Platform-specific setup and best practices

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       text: 'Quickstart',
       items: [
         { text: 'Agent Quickstart', link: '/quickstart/agent' },
+        { text: 'Tack: IPFS for Agents', link: '/quickstart/tack' },
         { text: 'Connect to Taiko', link: '/quickstart/connect' },
         { text: 'Deploy Your First Contract', link: '/quickstart/deploy' },
       ],
@@ -98,6 +99,7 @@ export default defineConfig({
 
   topNav: [
     { text: 'Docs', link: '/', match: '/' },
+    { text: 'Taiko', link: 'https://taiko.xyz' },
     { text: 'GitHub', link: 'https://github.com/taikoxyz/taiko-mono' },
     { text: 'Bridge', link: 'https://bridge.taiko.xyz' },
   ],

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -98,12 +98,8 @@ export default defineConfig({
   ],
 
   topNav: [
-<<<<<<< claude/slack-session-T4gt1
-    { text: 'Docs', link: '/', match: '/' },
-    { text: 'Taiko', link: 'https://taiko.xyz' },
-=======
     { text: 'Docs', link: 'https://github.com/taikoxyz/taiko-docs' },
->>>>>>> main
+    { text: 'Taiko', link: 'https://taiko.xyz' },
     { text: 'GitHub', link: 'https://github.com/taikoxyz/taiko-mono' },
     { text: 'Bridge', link: 'https://bridge.taiko.xyz' },
   ],


### PR DESCRIPTION
Incorporates feedback from Slack thread:
- New dedicated page for Tack at /quickstart/tack
- Hero: "One endpoint. Give it to your agent." (most visible)
- Subhead: "IPFS storage for AI agents. No API keys. No accounts."
- Leads with autonomy first, payment mechanics secondary
- Added cross-links to taiko.xyz in top nav
- Featured Tack prominently on landing page
- Updated agents guide with Tack section

https://taikolabs.slack.com/archives/C0613U7T022/p1775061749437969?thread_ts=1774885873.028999&cid=C0613U7T022

https://claude.ai/code/session_01S2QJBuGbFoCo71aeEg6pri