### PR TITLE
docs(skill): fix deploy/verify commands and stale explorer URLs

### DIFF
--- a/docs/pages/quickstart/connect.mdx
+++ b/docs/pages/quickstart/connect.mdx
@@ -11,7 +11,7 @@
 | Chain ID (Hex)    | `0x28C58`                            |
 | RPC URL           | `https://rpc.mainnet.taiko.xyz`      |
 | Explorer          | `https://taikoscan.io`               |
-| Explorer API      | `https://api.taikoscan.io/api`       |
+| Explorer API      | `https://api.etherscan.io/v2/api?chainid=167000` |
 | Bridge            | `https://bridge.taiko.xyz`           |
 | Native Currency   | ETH                                  |
 
@@ -24,7 +24,7 @@
 | Chain ID (Hex)    | `0x28C65`                            |
 | RPC URL           | `https://rpc.hoodi.taiko.xyz`        |
 | Explorer          | `https://hoodi.taikoscan.io`         |
-| Explorer API      | `https://api-hoodi.taikoscan.io/api` |
+| Explorer API      | `https://api.etherscan.io/v2/api?chainid=167013` |
 | Bridge            | `https://bridge.hoodi.taiko.xyz`     |
 | Native Currency   | ETH                                  |
 

--- a/docs/pages/resources/developer-tools.mdx
+++ b/docs/pages/resources/developer-tools.mdx
@@ -4,8 +4,8 @@
 
 | Tool | URL | Notes |
 | --- | --- | --- |
-| **Taikoscan** | [taikoscan.io](https://taikoscan.io) | Primary explorer. Etherscan-compatible API at `api.taikoscan.io/api`. |
-| **Taikoscan (Hoodi)** | [hoodi.taikoscan.io](https://hoodi.taikoscan.io) | Testnet explorer. API at `api-hoodi.taikoscan.io/api`. |
+| **Taikoscan** | [taikoscan.io](https://taikoscan.io) | Primary explorer. Verification API via Etherscan V2: `https://api.etherscan.io/v2/api?chainid=167000`. |
+| **Taikoscan (Hoodi)** | [hoodi.taikoscan.io](https://hoodi.taikoscan.io) | Testnet explorer. Verification API: `https://api.etherscan.io/v2/api?chainid=167013`. |
 | **Blockscout** | [blockscout.mainnet.taiko.xyz](https://blockscout.mainnet.taiko.xyz) | Alternative explorer with open-source API. |
 
 ## Bridge

--- a/docs/public/SKILL.md
+++ b/docs/public/SKILL.md
@@ -23,7 +23,7 @@ Taiko is a based rollup on Ethereum. "Based" means Ethereum L1 validators sequen
 | Explorer  | `https://taikoscan.io`          | `https://hoodi.taikoscan.io`    |
 | L1        | Ethereum (1)                    | Ethereum Hoodi (560048)         |
 | Currency  | ETH                             | ETH                             |
-| Bridge UI | `https://bridge.taiko.xyz`      | `https://bridge.hoodi.taiko.xyz |
+| Bridge UI | `https://bridge.taiko.xyz`      | `https://bridge.hoodi.taiko.xyz` |
 
 ## How Taiko Differs from Ethereum
 
@@ -81,10 +81,12 @@ Use standard EVM tools. No Taiko-specific SDK or CLI is required.
 - **ethers.js**: `new JsonRpcProvider("https://rpc.mainnet.taiko.xyz")`
 - **cast**: `cast call --rpc-url https://rpc.mainnet.taiko.xyz ...`
 
-For contract verification, use the explorer APIs:
+For contract verification, Taikoscan is served through the Etherscan V2 unified API. The same Etherscan API key works for every chain; the `chainid` query param routes the request.
 
-- Mainnet: `https://api.taikoscan.io/api` (Etherscan-compatible)
-- Testnet: `https://api-hoodi.taikoscan.io/api`
+- Mainnet: `https://api.etherscan.io/v2/api?chainid=167000`
+- Testnet: `https://api.etherscan.io/v2/api?chainid=167013`
+
+The old `api.taikoscan.io/api` / `api-hoodi.taikoscan.io/api` V1 endpoints are deprecated and will return an error.
 
 ## Contract Addresses — Mainnet L1 (Ethereum)
 
@@ -136,25 +138,30 @@ L2 contracts are predeployed at deterministic `0x167013...` addresses:
 ### Deploy a contract
 
 ```bash
-# Using Foundry (recommended) — use the taiko profile to target Shanghai EVM
+# Using Foundry (recommended) — use the taiko profile to target Shanghai EVM.
+# --broadcast is REQUIRED: without it forge create only simulates and nothing deploys.
 FOUNDRY_PROFILE=taiko forge create src/MyContract.sol:MyContract \
   --rpc-url https://rpc.mainnet.taiko.xyz \
   --private-key $PRIVATE_KEY \
+  --broadcast \
   --verify \
   --verifier etherscan \
-  --verifier-url https://api.taikoscan.io/api \
-  --etherscan-api-key $TAIKOSCAN_API_KEY
+  --verifier-url 'https://api.etherscan.io/v2/api?chainid=167000' \
+  --etherscan-api-key $ETHERSCAN_API_KEY
 ```
 
 ### Verify a contract
 
 ```bash
-forge verify-contract $CONTRACT_ADDRESS src/MyContract.sol:MyContract \
-  --chain-id 167000 \
+FOUNDRY_PROFILE=taiko forge verify-contract $CONTRACT_ADDRESS \
+  src/MyContract.sol:MyContract \
   --verifier etherscan \
-  --verifier-url https://api.taikoscan.io/api \
-  --etherscan-api-key $TAIKOSCAN_API_KEY
+  --verifier-url 'https://api.etherscan.io/v2/api?chainid=167000' \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --watch
 ```
+
+Swap `chainid=167000` → `chainid=167013` for Hoodi testnet.
 
 ### Read on-chain state
 
@@ -217,6 +224,6 @@ For the bridge UI: `https://bridge.taiko.xyz` or `https://bridge.hoodi.taiko.xyz
 
 For detailed guides, protocol design, node operation, and more:
 
-- All docs: `https://taiko-agent-docs.vercel.app/llms-full.txt`
-- Docs index: `https://taiko-agent-docs.vercel.app/llms.txt`
-- Web docs: `https://taiko-agent-docs.vercel.app`
+- All docs: `__SITE_URL__/llms-full.txt`
+- Docs index: `__SITE_URL__/llms.txt`
+- Web docs: `__SITE_URL__`


### PR DESCRIPTION
## Summary

SKILL.md is the file AI coding agents actually fetch, and it had two bugs that would silently break agent workflows, plus some stale links that didn't get caught in the earlier audit.

- **`forge create` example was missing `--broadcast`** — in modern Foundry this silently simulates without deploying. An agent following the old SKILL.md would believe it deployed a contract when nothing hit chain.
- **Explorer API URLs pointed at `api.taikoscan.io/api` (V1, deprecated)** — Taikoscan now returns "deprecated V1 endpoint, switch to Etherscan API V2" for these, so verification would fail. Swapped to `https://api.etherscan.io/v2/api?chainid=167000` / `167013` with a sentence explaining the old endpoints error out.
- **"Full Documentation" footer linked to `taiko-agent-docs.vercel.app`** — replaced with `__SITE_URL__`, which the `closeBundle` hook added in PR #6 rewrites per deployment (localhost in dev, preview URL on preview builds, prod URL once DNS flips).
- **Bridge UI row in the Quick Reference table had a dangling backtick** — cosmetic, fixed.
- **`developer-tools.mdx` and `connect.mdx` mirrored the same V1 URLs** in their public-facing explorer tables. Swapped both to the V2 endpoint so the Quick Reference / Developer Tools tables agree with what SKILL.md tells agents.

## Test plan

- [x] Run `VERCEL_ENV=production VERCEL_PROJECT_PRODUCTION_URL=docs.taiko.xyz pnpm build` and confirm `docs/dist/SKILL.md` renders the substituted URL in the Full Documentation section
- [x] Confirm zero `__SITE_URL__` sentinels remain in `dist/` after build
- [x] Confirm the only remaining `api.taikoscan.io/api` references in `dist/` are the intentional deprecation explanations (in `SKILL.md`, `deploy.md`, `llms-full.txt`, search index)
- [x] Spot-check `forge create --help` to confirm `--broadcast` is still required in Foundry 1.4.x
- [ ] After merge: fetch `https://docs.taiko.xyz/SKILL.md` once the site redeploys and confirm the Full Documentation links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)