### PR TITLE
ci: drop --prebuilt flow so Vercel native build populates system env vars

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -26,31 +26,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Install Vercel CLI
-        run: pnpm add --global vercel@latest
-
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy Project Artifacts to Vercel
+      - name: Deploy to Vercel
         id: deploy
         run: |
-          DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          DEPLOY_URL=$(npx vercel@latest deploy --yes --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
 
       - name: Comment preview URL on PR

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,26 +21,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Install Vercel CLI
-        run: pnpm add --global vercel@latest
-
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy to Vercel
+        run: npx vercel@latest deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vocs dev",
-    "build": "vocs build",
+    "build": "vocs build && node scripts/substitute-site-url.mjs",
     "preview": "vocs preview"
   },
   "dependencies": {

--- a/scripts/site-url.mjs
+++ b/scripts/site-url.mjs
@@ -1,0 +1,18 @@
+// Shared site-URL resolution for vocs.config.ts (dev + Vite transform) and
+// scripts/substitute-site-url.mjs (post-build pass over dist/).
+//
+// Chain: explicit SITE_URL override → Vercel production alias → Vercel branch
+// URL (stable per branch) → Vercel deployment URL → local dev fallback.
+//
+// All VERCEL_* vars are populated at build time only when Vercel builds
+// natively — the --prebuilt flow does NOT expose them. Our GitHub workflows
+// use `vercel deploy` (non-prebuilt) so Vercel builds on its own infra.
+export const siteUrl =
+  process.env.SITE_URL ??
+  (process.env.VERCEL_ENV === 'production' && process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : process.env.VERCEL_BRANCH_URL
+      ? `https://${process.env.VERCEL_BRANCH_URL}`
+      : process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : 'http://localhost:5173')

--- a/scripts/substitute-site-url.mjs
+++ b/scripts/substitute-site-url.mjs
@@ -1,12 +1,22 @@
-// Post-build pass that replaces every __SITE_URL__ sentinel in docs/dist
-// with the resolved siteUrl. Runs after `vocs build` fully exits, so it
-// catches files written by Vite's transform pipeline, Vocs's llms plugin
-// (.md/.txt exports), and Vite's public-dir copy (docs/public/SKILL.md).
-import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+// Post-build pass that replaces every __SITE_URL__ sentinel in the build
+// output with the resolved siteUrl. Runs after `vocs build` fully exits,
+// so it catches files written by Vite's transform pipeline, Vocs's llms
+// plugin (.md/.txt exports), and Vite's public-dir copy (docs/public/SKILL.md).
+//
+// Vocs picks the output directory based on whether it detects Vercel:
+// - Local / CI outside Vercel:  docs/dist
+// - Vercel native build:        .vercel/output/static  (Build Output API v3)
+//
+// See node_modules/vocs/_lib/vite/utils/resolveOutDir.js.
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { siteUrl } from './site-url.mjs'
 
-const outDir = 'docs/dist'
+const outDir = process.env.VERCEL ? '.vercel/output/static' : 'docs/dist'
+if (!existsSync(outDir)) {
+  console.error(`[site-url] build output dir ${outDir} not found — did vocs build succeed?`)
+  process.exit(1)
+}
 const textExts = new Set(['.md', '.txt', '.json', '.html', '.js'])
 
 let replaced = 0

--- a/scripts/substitute-site-url.mjs
+++ b/scripts/substitute-site-url.mjs
@@ -1,0 +1,30 @@
+// Post-build pass that replaces every __SITE_URL__ sentinel in docs/dist
+// with the resolved siteUrl. Runs after `vocs build` fully exits, so it
+// catches files written by Vite's transform pipeline, Vocs's llms plugin
+// (.md/.txt exports), and Vite's public-dir copy (docs/public/SKILL.md).
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { siteUrl } from './site-url.mjs'
+
+const outDir = 'docs/dist'
+const textExts = new Set(['.md', '.txt', '.json', '.html', '.js'])
+
+let replaced = 0
+const walk = (dir) => {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      walk(full)
+      continue
+    }
+    const dot = entry.lastIndexOf('.')
+    if (dot < 0 || !textExts.has(entry.slice(dot))) continue
+    const contents = readFileSync(full, 'utf8')
+    if (!contents.includes('__SITE_URL__')) continue
+    writeFileSync(full, contents.replaceAll('__SITE_URL__', siteUrl))
+    replaced += 1
+  }
+}
+
+walk(outDir)
+console.log(`[site-url] rewrote ${replaced} files in ${outDir} with ${siteUrl}`)

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -6,9 +6,11 @@ const siteUrl =
   process.env.SITE_URL ??
   (process.env.VERCEL_ENV === 'production' && process.env.VERCEL_PROJECT_PRODUCTION_URL
     ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-    : process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : 'http://localhost:5173')
+    : process.env.VERCEL_BRANCH_URL
+      ? `https://${process.env.VERCEL_BRANCH_URL}`
+      : process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : 'http://localhost:5173')
 
 export default defineConfig({
   title: 'Taiko Docs',

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,16 +1,5 @@
-import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { defineConfig } from 'vocs'
-
-const siteUrl =
-  process.env.SITE_URL ??
-  (process.env.VERCEL_ENV === 'production' && process.env.VERCEL_PROJECT_PRODUCTION_URL
-    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-    : process.env.VERCEL_BRANCH_URL
-      ? `https://${process.env.VERCEL_BRANCH_URL}`
-      : process.env.VERCEL_URL
-        ? `https://${process.env.VERCEL_URL}`
-        : 'http://localhost:5173')
+import { siteUrl } from './scripts/site-url.mjs'
 
 export default defineConfig({
   title: 'Taiko Docs',
@@ -105,40 +94,16 @@ export default defineConfig({
   vite: {
     plugins: [
       {
-        name: 'docs-site-url',
+        // Dev-server substitution: rewrites __SITE_URL__ in .mdx files at
+        // load time so `pnpm dev` shows http://localhost:5173. The static
+        // build is handled by scripts/substitute-site-url.mjs running after
+        // `vocs build` — this hook is a dev-mode convenience only.
+        name: 'docs-site-url-dev',
         enforce: 'pre',
-        // Dev + HTML/JS builds: substitute at MDX load time.
         transform(code, id) {
           if (!id.includes('.mdx')) return null
           if (!code.includes('__SITE_URL__')) return null
           return { code: code.replaceAll('__SITE_URL__', siteUrl), map: null }
-        },
-        // Prod build only: rewrite the .md / llms-full.txt / llms.txt / search index
-        // that Vocs's llms plugin writes directly to outDir, bypassing Vite's transform.
-        closeBundle() {
-          const outDir = 'docs/dist'
-          const textExts = new Set(['.md', '.txt', '.json', '.html', '.js'])
-          const walk = (dir: string) => {
-            for (const entry of readdirSync(dir)) {
-              const full = join(dir, entry)
-              const stat = statSync(full)
-              if (stat.isDirectory()) {
-                walk(full)
-                continue
-              }
-              const dot = entry.lastIndexOf('.')
-              if (dot < 0) continue
-              if (!textExts.has(entry.slice(dot))) continue
-              const contents = readFileSync(full, 'utf8')
-              if (!contents.includes('__SITE_URL__')) continue
-              writeFileSync(full, contents.replaceAll('__SITE_URL__', siteUrl))
-            }
-          }
-          try {
-            walk(outDir)
-          } catch (e) {
-            // outDir may not exist in some build modes; ignore.
-          }
         },
       },
     ],


### PR DESCRIPTION
## Why

PR #8 shipped a `__SITE_URL__` sentinel that gets substituted at build time to whatever the deployment's URL is. On the live production deploy it instead resolved to `http://localhost:5173` — the dev fallback — because the existing workflow uses Vercel's prebuilt flow:

\`\`\`yaml
vercel pull --yes --environment=production
vercel build --prod
vercel deploy --prebuilt --prod
\`\`\`

- \`vercel pull\` dumps env vars to \`.vercel/.env.production.local\`, but \`VERCEL_PROJECT_PRODUCTION_URL\` is not included in that dump.
- \`VERCEL_URL\` is the deployment's URL — it doesn't exist until \`vercel deploy\` is called, which happens **after** \`vercel build\`.
- So when \`vocs.config.ts\` reads \`process.env\` during \`vercel build\`, both are unset, and the config chain falls through to the localhost fallback.

No amount of config-time logic can fix this: at \`vercel build --prod\` time, the deployment URL is literally not known yet.

## Fix

Stop building on the arc-runner and let Vercel build natively. When the build runs inside Vercel's own infra, all three system env vars (\`VERCEL_PROJECT_PRODUCTION_URL\`, \`VERCEL_BRANCH_URL\`, \`VERCEL_URL\`) are populated at build time — per [the Vercel system env var docs](https://vercel.com/docs/projects/environment-variables/system-environment-variables) (all three listed as "Available at Build Time").

The previous workflow was ~45 lines doing \`install pnpm → install node → pnpm install → vercel pull → vercel build → vercel deploy --prebuilt\`. The new one is ~20 lines doing \`install node → npx vercel deploy\`. Vercel handles pnpm install and the build via \`vercel.json\`.

## Changes

- **\`vocs.config.ts\`**: insert \`VERCEL_BRANCH_URL\` into the resolution chain between the prod URL and the deployment URL, so preview builds get a stable per-branch link (\`agent-docs-git-<branch>-taikoxyz.vercel.app\`) instead of the per-deployment one.
- **\`deploy-production.yml\`**: drop pnpm setup, \`vercel pull\`, \`vercel build\`, and \`--prebuilt\`. Single \`npx vercel@latest deploy --prod --yes\` step.
- **\`deploy-preview.yml\`**: same cleanup. Keeps the deploy-URL capture and PR comment.

## Test plan

- [ ] CI runs deploy-preview workflow successfully
- [ ] Vercel native build completes (will be slower than arc-runner build but should finish)
- [ ] Visit the preview URL and confirm the prompt blocks on \`/quickstart/agent\` show the **preview's own URL** (\`agent-docs-git-fix-native-vercel-build-taikoxyz.vercel.app/SKILL.md\`) instead of \`localhost:5173\`
- [ ] After merge, confirm production shows the prod URL (\`agent-taiko-docs.vercel.app/SKILL.md\` or \`docs.taiko.xyz/SKILL.md\` post-DNS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)