### PR TITLE
fix(docs): show Taiko logo in browser tab favicon

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   description: 'Documentation for Taiko, a based rollup on Ethereum',
 
   logoUrl: { dark: '/logo-dark.svg', light: '/logo-light.svg' },
+  iconUrl: '/favicon.svg',
 
   theme: {
     accentColor: { light: '#e81899', dark: '#fc5cb5' },


### PR DESCRIPTION
## Summary
- Wire `docs/public/favicon.svg` into `vocs.config.ts` via `iconUrl` so browser tabs render the Taiko logo instead of the generic browser default.
- The asset already shipped in `docs/public/` but was never referenced from the config, so vocs was emitting no `<link rel="icon">` pointing at it.

## Test plan
- [x] `pnpm build` succeeds
- [x] Built `docs/dist/index.html` now contains `<link rel="icon" href="/favicon.svg" type="image/svg+xml">`
- [ ] Load the deployed preview in a browser and confirm the tab shows the Taiko logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)