### PR TITLE
Add Envio to Taiko indexing tools

### DIFF
--- a/docs/pages/resources/developer-tools.mdx
+++ b/docs/pages/resources/developer-tools.mdx
@@ -72,6 +72,7 @@ For production applications, use a dedicated RPC provider to avoid public rate l
 
 | Service | Link |
 | --- | --- |
+| **Envio** | [docs.envio.dev/HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=taiko&utm_medium=partner-docs) |
 | **GoldRush (Covalent)** | [goldrush.dev/docs/chains/taiko](https://goldrush.dev/docs/chains/taiko?utm_source=taiko&utm_medium=partner-docs) |
 | **Goldsky** | [docs.goldsky.com/chains/taiko](https://docs.goldsky.com/chains/taiko/?utm_source=taiko&utm_medium=docs) |
 | **The Graph** | Any EVM-compatible subgraph works with Taiko. |

--- a/docs/pages/resources/developer-tools.mdx
+++ b/docs/pages/resources/developer-tools.mdx
@@ -72,7 +72,7 @@ For production applications, use a dedicated RPC provider to avoid public rate l
 
 | Service | Link |
 | --- | --- |
-| **Envio** | [docs.envio.dev/HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=taiko&utm_medium=partner-docs) |
+| **Envio** | [docs.envio.dev/HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=taiko&utm_medium=partner-docs), [Benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=taiko&utm_medium=partner-docs) |
 | **GoldRush (Covalent)** | [goldrush.dev/docs/chains/taiko](https://goldrush.dev/docs/chains/taiko?utm_source=taiko&utm_medium=partner-docs) |
 | **Goldsky** | [docs.goldsky.com/chains/taiko](https://docs.goldsky.com/chains/taiko/?utm_source=taiko&utm_medium=docs) |
 | **The Graph** | Any EVM-compatible subgraph works with Taiko. |

--- a/docs/pages/resources/developer-tools.mdx
+++ b/docs/pages/resources/developer-tools.mdx
@@ -72,7 +72,7 @@ For production applications, use a dedicated RPC provider to avoid public rate l
 
 | Service | Link |
 | --- | --- |
-| **Envio** | [docs.envio.dev/HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=taiko&utm_medium=partner-docs) |
+| **Envio** | [envio.dev](https://envio.dev/?utm_source=taiko&utm_medium=partner-docs) |
 | **GoldRush (Covalent)** | [goldrush.dev/docs/chains/taiko](https://goldrush.dev/docs/chains/taiko?utm_source=taiko&utm_medium=partner-docs) |
 | **Goldsky** | [docs.goldsky.com/chains/taiko](https://docs.goldsky.com/chains/taiko/?utm_source=taiko&utm_medium=docs) |
 | **The Graph** | Any EVM-compatible subgraph works with Taiko. |

--- a/docs/pages/resources/developer-tools.mdx
+++ b/docs/pages/resources/developer-tools.mdx
@@ -72,7 +72,7 @@ For production applications, use a dedicated RPC provider to avoid public rate l
 
 | Service | Link |
 | --- | --- |
-| **Envio** | [docs.envio.dev/HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=taiko&utm_medium=partner-docs), [Benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=taiko&utm_medium=partner-docs) |
+| **Envio** | [docs.envio.dev/HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=taiko&utm_medium=partner-docs) |
 | **GoldRush (Covalent)** | [goldrush.dev/docs/chains/taiko](https://goldrush.dev/docs/chains/taiko?utm_source=taiko&utm_medium=partner-docs) |
 | **Goldsky** | [docs.goldsky.com/chains/taiko](https://docs.goldsky.com/chains/taiko/?utm_source=taiko&utm_medium=docs) |
 | **The Graph** | Any EVM-compatible subgraph works with Taiko. |


### PR DESCRIPTION
This adds an Envio row to the Indexing table on the Developer Tools page.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Its HyperIndex supports indexing any EVM chain out of the box, so developers can index Taiko (chain ID 167000) using their own RPC as the data source. Indexers can be self-hosted or run on the managed Envio Cloud service.

Website: https://envio.dev/
Docs: https://docs.envio.dev/