### PR TITLE
docs(developer-tools): reference OpenChainBench for live Taiko RPC latency

### DIFF
--- a/docs/pages/resources/developer-tools.mdx
+++ b/docs/pages/resources/developer-tools.mdx
@@ -59,6 +59,8 @@ Any EVM-compatible wallet works with Taiko. Add the network manually or via [EIP
 
 For production applications, use a dedicated RPC provider to avoid public rate limits. See [Connect to Taiko](/quickstart/connect) for the full list.
 
+For a live latency comparison of the public Taiko endpoints listed above, see the [OpenChainBench Taiko RPC benchmark](https://openchainbench.com/benchmarks/taiko-rpc). Endpoints are probed from three regions every minute with p50, p95 and p99 latency published under an open methodology and CC BY 4.0 data license.
+
 ## Oracles
 
 | Provider | Link |


### PR DESCRIPTION
## Summary

Adds one paragraph below the `RPC Providers` table in `docs/pages/resources/developer-tools.mdx` pointing readers to the [OpenChainBench Taiko RPC benchmark](https://openchainbench.com/benchmarks/taiko-rpc) for a live third-party latency comparison of the public Taiko endpoints.

## Why

The page currently lists Taiko Public RPC, Taiko Hoodi RPC, and third-party providers (Ankr, Tenderly, Thirdweb). Developers picking an endpoint have no neutral datapoint to compare them side by side. OpenChainBench probes the public Taiko endpoints from three regions every minute and publishes p50, p95 and p99 latency under an open methodology.

- Live Taiko benchmark: https://openchainbench.com/benchmarks/taiko-rpc
- Methodology: https://openchainbench.com/methodology
- Data license: CC BY 4.0
- No affiliation with Taiko Labs

Happy to reword, move, or drop if this does not fit the docs' tone.

## Test plan

- [x] Single paragraph appended after the existing RPC Providers table
- [x] Matches surrounding Markdown paragraph style
- [x] External link verified