### PR TITLE
docs: add OpenChainBench as live Taiko RPC latency reference

### DIFF
--- a/docs/pages/resources/developer-tools.mdx
+++ b/docs/pages/resources/developer-tools.mdx
@@ -59,6 +59,8 @@ Any EVM-compatible wallet works with Taiko. Add the network manually or via [EIP
 
 For production applications, use a dedicated RPC provider to avoid public rate limits. See [Connect to Taiko](/quickstart/connect) for the full list.
 
+For a live latency comparison of the public Taiko endpoints listed above, see the [OpenChainBench Taiko RPC benchmark](https://openchainbench.com/benchmarks/taiko-rpc). Endpoints are probed from three regions every minute with p50, p95 and p99 latency published under an open methodology and CC BY 4.0 data license.
+
 ## Oracles
 
 | Provider | Link |


### PR DESCRIPTION
This resubmits PR #19, originally opened by @Flotapponnier, who maintains OpenChainBench.

His personal account was incorrectly caught by GitHub's automated spam detection last week (an appeal is in progress with GitHub Support), which made the original PR invisible to reviewers. We apologize for the confusion and the extra noise. We are submitting from the project account so the change does not go stale.

The change adds one paragraph to the developer tools page: a link to the [OpenChainBench Taiko RPC benchmark](https://openchainbench.com/benchmarks/taiko-rpc), so readers can compare live latency of the public endpoints listed on that page. Methodology is open and the data is published under CC BY 4.0.

Happy to address any feedback.